### PR TITLE
Add SetupTeardown tests

### DIFF
--- a/src/NUnit-retry.Tests/NUnit-retry.Tests.csproj
+++ b/src/NUnit-retry.Tests/NUnit-retry.Tests.csproj
@@ -33,10 +33,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -44,6 +40,9 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="nunit.framework">
+      <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="FixtureTests.cs" />
@@ -51,13 +50,14 @@
     <Compile Include="MethodTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SetUpTests.cs" />
+    <Compile Include="SetupTeardownTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NUnit-retry\NUnit-retry.csproj">
-      <Project>{8eb152c4-2508-40c9-83b3-c745ef15b3af}</Project>
+      <Project>{8EB152C4-2508-40C9-83B3-C745EF15B3AF}</Project>
       <Name>NUnit-retry</Name>
     </ProjectReference>
   </ItemGroup>

--- a/src/NUnit-retry.Tests/SetupTeardownTests.cs
+++ b/src/NUnit-retry.Tests/SetupTeardownTests.cs
@@ -1,0 +1,45 @@
+﻿// /////////////////////////////////////////////////////////////////////
+//  This is free software licensed under the NUnit license. You
+//  may obtain a copy of the license as well as information regarding
+//  copyright ownership at http://nunit.org.    
+// /////////////////////////////////////////////////////////////////////
+
+namespace NUnit_retry.Tests
+{
+    using System;
+    using NUnit.Framework;
+
+    public class BaseTestSuite
+    {
+        public object test = null;
+
+        public virtual void Init() {
+            test = new object();
+        }
+
+        public virtual void UnInit() {
+            test = null;
+        }
+    }
+    [TestFixture]
+    public class SetupTeardownTests : BaseTestSuite
+    {
+        [SetUp]
+        public override void Init() {
+            base.Init();
+        }
+
+        [TearDown]
+        public override void UnInit() {
+            base.UnInit();
+        }
+            
+        [Test]
+        [Retry(Times = 3, RequiredPassCount = 2)]
+        public void FixtureSetupTeardown()
+        {
+            Assert.That(base.test != null, "Did not call [Setup]");
+        }
+    }
+}
+


### PR DESCRIPTION
Currently tests with retry attribute do not call Setup/Teardown.
Added a test for Setup/Teardown which fails right now.
Thanks for looking into this.
